### PR TITLE
fix pip.req import error by not using pip internal modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,9 @@
 """ Interact with Extreme Networks devices running EXOS """
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
-import uuid
 
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
-
-# reqs is a list of requirement
-# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-reqs = [str(ir.req) for ir in install_reqs]
+with open("requirements.txt") as f:
+    reqs = f.read().strip().split('\n')
 
 version = '0.2'
 


### PR DESCRIPTION
parse_requirements has been moved from pip.req to pip._internal so installing with newer versions of pip throws this error:

python setup.py install
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    from pip.req import parse_requirements
ModuleNotFoundError: No module named 'pip.req'
